### PR TITLE
[feature] [TDET-61] A DAG for fetching indices data

### DIFF
--- a/dags/brz_index_daily/brz_index_daily.py
+++ b/dags/brz_index_daily/brz_index_daily.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from common.constants import Interval, Layer, Owner
+
+from brz_index_daily.constants import INDEX_DATA_S3_KEY, INDEX_TMP_FILE_PATH, SYMBOLS
+from brz_index_daily.extractors import fetch_index_data
+
+with DAG(
+    dag_id="brz_index_daily",
+    default_args={
+        "owner": Owner.MINHYEOK,
+        "retries": 3,
+        "retry_delay": timedelta(minutes=5),
+    },
+    schedule_interval="0 0 * * 1-5",
+    start_date=datetime(2024, 12, 1),
+    catchup=True,
+    max_active_tasks=5,
+    tags=[Layer.BRONZE, Interval.DAILY.label],
+) as dag:
+    fetch_index_data_task = PythonOperator(
+        task_id="fetch_index_data",
+        python_callable=fetch_index_data,
+        provide_context=True,
+        op_kwargs={
+            "symbols": SYMBOLS,
+            "index_tmp_file_path": INDEX_TMP_FILE_PATH,
+            "index_data_s3_key": INDEX_DATA_S3_KEY,
+        },
+    )
+
+    fetch_index_data_task

--- a/dags/brz_index_daily/constants.py
+++ b/dags/brz_index_daily/constants.py
@@ -1,0 +1,21 @@
+# 수집할 인덱스 심볼과 URL
+SYMBOLS = {
+    "FTASEANAS": "961167",  # FTSE 아세안 종합지수(FTSE ASEAN All-Share Index)
+    "SSEC": "40820",  # 상해 종합 지수 (중국, Shanghai Composite Index)
+    "HSI": "179",  # 항생 지수 (홍콩, Hang Seng Index)
+    "NSEI": "17940",  # 니프티 50 (인도, Nifty 50 Index)
+    "IBOV": "17920",  # 이보베스파 (브라질, Ibovespa)
+    "JTOPI": "41043",  # FTSE/JSE top 40 (남아공, FTSE/JSE Top 40 Index)
+    "MIAP00000PUS": "942944",  # MSCI AC asia (아시아 중소국가 종합 지수, MSCI AC Asia Index)
+    "SPX": "166",  # S&P 500 (미국, S&P 500 Index)
+    "DJI": "169",  # 다우 존스 산업평균 (미국, Dow Jones Industrial Average)
+    "FTSE": "27",  # 프린스트 종합 지수 (영국, FTSE All-Share Index)
+    "DAX": "172",  # 도일 종합 지수 (독일, DAX Index)
+    "CAC": "167",  # 카프 종합 지수 (프랑스, CAC 40 Index)
+    "ASX": "171",  # 오스트레일리아 종합 지수 (오스트레일리아, ASX All Ordinaries Index)
+}
+
+# 인덱스 데이터 수집 임시 파일 경로
+INDEX_TMP_FILE_PATH = "/tmp/index_data_{{ ds }}.json"
+# 인덱스 데이터 수집 데이터 파일 S3 키
+INDEX_DATA_S3_KEY = "bronze/index_data/ymd={{ ds }}/{{ ds }}_index_data.json"

--- a/dags/brz_index_daily/constants.py
+++ b/dags/brz_index_daily/constants.py
@@ -1,4 +1,4 @@
-# 수집할 인덱스 심볼과 URL
+# 수집할 인덱스 심볼과 URL 코드
 SYMBOLS = {
     "FTASEANAS": "961167",  # FTSE 아세안 종합지수(FTSE ASEAN All-Share Index)
     "SSEC": "40820",  # 상해 종합 지수 (중국, Shanghai Composite Index)

--- a/dags/brz_index_daily/extractors.py
+++ b/dags/brz_index_daily/extractors.py
@@ -1,0 +1,53 @@
+import json
+import logging
+
+import cloudscraper
+from common.s3_utils import upload_file_to_s3
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_index_data(symbols, index_tmp_file_path, index_data_s3_key, **kwargs):
+    modified_response = {}
+
+    for symbol, code in symbols.items():
+        # cloudscraper 객체 생성
+        scraper = cloudscraper.create_scraper()
+        # URL 설정
+        url = f"https://api.investing.com/api/financialdata/historical/{code}"
+
+        # 요청 파라미터 설정
+        params = {
+            "start-date": kwargs["logical_date"].strftime("%Y-%m-%d"),
+            "end-date": kwargs["logical_date"].strftime("%Y-%m-%d"),
+            "time-frame": "Daily",
+            "add-missing-rows": "false",
+        }
+
+        # 필수 헤더 설정
+        headers = {
+            "domain-id": "www",
+        }
+
+        # GET 요청 보내기
+        response = scraper.get(url, headers=headers, params=params)
+        logger.info(f"response.status_code: {response.status_code}")
+
+        # 에러 발생 시 Exception 발생
+        if response.status_code != 200:
+            raise Exception(f"Error fetching data for {symbol}: {response.text}")
+
+        response_json = response.json()
+        # 휴장일에는 데이터가 None으로 반환됨 - 각 시장마다 휴장일이 다르므로 이렇게 처리
+        if response_json["data"] is not None:
+            modified_response[symbol] = response_json["data"][0]
+
+    # json 파일로 저장
+    with open(index_tmp_file_path, "w") as f:
+        json.dump(modified_response, f, indent=4)
+
+    # s3에 업로드
+    upload_file_to_s3(
+        key=index_data_s3_key,
+        file_path=index_tmp_file_path,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ yfinance==0.2.51
 requests
 bs4
 apache-airflow-providers-amazon
+cloudscraper


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [prefix][JIRA-ticket-number] 상세 내용 -->
## 개요
<!-- 이 PR에서 작업한 내용과 해결하고자 하는 문제를 간단히 설명합니다. -->
Investing.com을 통해 대표적인 여러 나라의 종합 주가 지수 데이터를 수집합니다.
- 수집 대상: `FTSE 아세안 종합지수`, `상해 종합 지수(중국)`, `항생 지수(홍콩)`, `니프티50(인도)`, `이보베스파(브라질)`, F`TSE/JSE top40(남아공)`, `MSCI AC asia(아시아 중소국가)`, `S&P 500(미국)`, `다우 존스 산업평균지수(미국)`, `프린스트 종합 지수(영국)`, `도일 종합 지수(독일)`, `카프 종합 지수(프랑스)`, `호주 종합 지수(호주)`

## 변경 사항
<!-- 주요 변경점이나 추가된 기능을 요약합니다. -->
<!-- 무엇을 구현하려고 했는지 자세히 설명합니다. -->
<!-- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Investing.com의 api 호출 링크(fetch)를 통해 데이터를 수집합니다.
- `cloudscraper` 라이브러리를 이용해 JavaScript 처리 및 쿠키 설정을 자동으로 처리했습니다.
- 모든 종합 지수 데이터를 json 형식으로 저장 후 S3에 업로드합니다.
- [뉴스 데이터 수집 DAG 코멘트](https://github.com/DE-ta-e-il/catch-me-my-capital/pull/14)를 반영해 모듈을 사용하는 곳에서 호출하도록 수정했습니다.

## 테스트 결과
<!-- 실행이 가능한 코드라면, 반드시 실행이 되는지 확인하고 테스트한 결과를 함께 올립니다. -->
[Airflow 그래프 확인]
![image](https://github.com/user-attachments/assets/4d425549-16ce-48e3-b96f-b595bbdad37b)

[S3 업로드 확인]
![image](https://github.com/user-attachments/assets/aaec5b9f-1319-419a-adb3-89dd18f345ee)

[데이터 확인]
![image](https://github.com/user-attachments/assets/8e2a517a-8abb-4fd0-9060-908a5b0fb0c6)


## 리뷰 요청 사항
<!--- 리뷰어가 중점적으로 검토해야 하는 부분이나 피드백이 필요한 사항을 명시합니다. -->
<!-- 논의해야할 부분이 있다면 적어주세요.-->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) 이 부분의 로직이 간결한지, 성능 개선 여지가 있는지 검토 부탁드립니다. -->
- [뉴스 데이터 수집 DAG 코멘트](https://github.com/DE-ta-e-il/catch-me-my-capital/pull/14)에서 말씀하신 부분과 제가 구현한 것이 맞는지 확인 부탁드리겠습니다! (`brz_index_daily.py` 파일)